### PR TITLE
Add package-lock.json and yarn.lock to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,10 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+
+# Lock Files 
+
+yarn.lock
+package-lock.json
+


### PR DESCRIPTION
The package-lock.json and yarn.lock are arquives that the packages managers create to control the lib instalition they are unesesary to in github because when install dependencys with `npm install` or `yarn` they are created.